### PR TITLE
Wandb Integration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - sentencepiece=0.* # can omit if sentencepiece models (e.g. ALBERT, XLMRoberta, T5) are not needed
   - hydra-core=1.3.*
   - strenum
+  - wandb=0.*
   # Uncomment following packages if audio processing is needed:
   # - librosa=0.*
   # - pysoundfile>=0.12.1

--- a/gpu_environment.yml
+++ b/gpu_environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - sentencepiece=0.* # can omit if sentencepiece models (e.g. ALBERT, XLMRoberta, T5) are not needed
   - hydra-core=1.3.*
   - strenum
+  - wandb=0.*
   # Uncomment following packages if audio processing is needed:
   # - librosa=0.*
   # - pysoundfile>=0.12.1


### PR DESCRIPTION
Originally, the code for this PR was slightly more involved; however, I realized that the default setting in transformers is to turn on all loggers (including wanddb); this is turned off by setting `report_to="none"` in `TrainingArguments`. So as long as `wanddb` is installed to the environment, and the login credentials are saved as environment variables, everything just works as is- so I deleted the little code snippet that handled reading environment variables etc. This commit just updates the Conda environment files.