### PR TITLE
Adding a custom resolver because of a Hydra bug

### DIFF
--- a/config/model/config/recurrent_base.yaml
+++ b/config/model/config/recurrent_base.yaml
@@ -2,10 +2,6 @@ defaults:
   - _self_
 _target_: model.RNNConfig
 rnn_type: ???
-# it would be nice to infer this automatically from a tokenizer vocab, but doing so
-# would require instantiating the tokenizer, which is not possible in the config
-# in other words, would lose the maximal dependency injection that we currently have
-vocab_size: 50002
 embedding_dim: 1024
 hidden_dim: 1024
 num_layers: 2

--- a/src/train_lm.py
+++ b/src/train_lm.py
@@ -8,7 +8,9 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerFast
 import numpy as np
-    
+
+# resolver to split a string x on a character y and return the (z-1)th element
+OmegaConf.register_new_resolver("split", lambda x, y, z: x.split(y)[z])
 
 @hydra.main(config_path="../config", config_name="train-lm", version_base=None)
 def train_lm(cfg: DictConfig) -> None:


### PR DESCRIPTION
I reported the bug here- https://github.com/facebookresearch/hydra/issues/2800. They fixed it overnight but until that gets deployed, this workaround will have to do

I use this resolver in the corpus-filtering project to store information in a string, with each field separated by dashes, in the job name, and then later extract that information within `hydra.job.env_set`. I know that's probably a bit arcane-sounding but it'll become clear when I cut the corresponding corpus-filtering PR.

Technically speaking this change isn't necessary for this repo itself, only for corpus-filtering, but I'm not sure where else to put it, since our training procedure for corpus-filtering involves calling `train-lm.py` here.

(Also deleted a redundant bit in one of the configs; that commit was supposed to be part of the last PR)