### PR TITLE
RM ds_dict drop col text

### DIFF
--- a/src/train_lm.py
+++ b/src/train_lm.py
@@ -70,7 +70,6 @@ def train_lm(cfg: DictConfig) -> None:
     """
     log.info(f"Config:\n{OmegaConf.to_yaml(cfg)}")
     ds_dict: DatasetDict = hydra.utils.instantiate(cfg.dataset, _convert_="object")
-    ds_dict = ds_dict.remove_columns("text")
     tokenizer: PreTrainedTokenizerFast = hydra.utils.instantiate(cfg.tokenizer)
     if not cfg.data.get("is_tokenized", False):
         log.info("Tokenizing dataset.")


### PR DESCRIPTION
The presence of the following line is causing downstream issues in babylm. Proposing to roll it back, but I wanted to check to see if I was missing something. What's the line meant to be doing here? Forgive my ignorance as I catch up here.
```
ds_dict = ds_dict.remove_columns("text")
```