### PR TITLE
Prefix LM configs

### DIFF
--- a/config/collator/prefix_modeling.yaml
+++ b/config/collator/prefix_modeling.yaml
@@ -1,3 +1,3 @@
 _target_: trl.DataCollatorForCompletionOnlyLM
 mlm: False
-response_template: ???
+response_template: ${tokenizer.sep_token}

--- a/config/collator/prefix_modeling.yaml
+++ b/config/collator/prefix_modeling.yaml
@@ -1,0 +1,3 @@
+_target_: trl.DataCollatorForCompletionOnlyLM
+mlm: False
+response_template: ???

--- a/config/tokenizer/word-level-prefix.yaml
+++ b/config/tokenizer/word-level-prefix.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - word-level  # Inherit from word-level.yaml
+
+trainer:
+  special_tokens: # Extend the existing list of special tokens
+    - ${tokenizer.model.unk_token}
+    - "<eos>"
+    - "<pad>"
+    - "<sep>"

--- a/config/train-from-prefix-config.yaml
+++ b/config/train-from-prefix-config.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - train-lm
+  - model: from_config
+  - collator: prefix_modeling
+  - _self_
+
+model:
+  config:
+      # it would be nice to infer this automatically from a tokenizer vocab, but doing so
+      # would require instantiating the tokenizer, which is not possible in the config
+      # in other words, would lose the maximal dependency injection that we currently have
+      vocab_size: 50002
+
+# Override the tokenizer configuration from train-lm.yaml
+tokenizer:
+  tokenizer_file: models/tokenizer/word-level-prefix.json  # New tokenizer file path
+  unk_token: "<unk>"   # New unknown token, if you need to change it
+  eos_token: "<eos>"   # New end-of-sequence token, if you need to change it
+  pad_token: "<pad>"   # New padding token, if you need to change it
+  sep_token: "<sep>"   # New separator token, if you need to change it
+
+# Override the collator configurtion from prefix_modeling.yaml
+# Assumes the data to be formatted as "<input_sequence> <sep_token> <output_sequence>"
+collator:
+  response_template: ${tokenizer.sep_token}

--- a/config/train-from-prefix-config.yaml
+++ b/config/train-from-prefix-config.yaml
@@ -19,7 +19,6 @@ tokenizer:
   pad_token: "<pad>"   # New padding token, if you need to change it
   sep_token: "<sep>"   # New separator token, if you need to change it
 
-# Override the collator configurtion from prefix_modeling.yaml
-# Assumes the data to be formatted as "<input_sequence> <sep_token> <output_sequence>"
-collator:
-  response_template: ${tokenizer.sep_token}
+# Note that the collator configurtion from prefix_modeling.yaml assumes the 
+# data to be formatted as "<input_sequence> <sep_token> <output_sequence>".
+# To modify the response_template, override the collator response_template.

--- a/config/train-prefix-transformer.yaml
+++ b/config/train-prefix-transformer.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - train-from-prefix-config
+  - override model/config: causal-small
+  - _self_

--- a/src/train_lm.py
+++ b/src/train_lm.py
@@ -199,7 +199,7 @@ def train_lm(cfg: DictConfig) -> None:
             # args=training_args,
             train_dataset=train_ds,
             eval_dataset=eval_ds,
-            data_collator=data_collator,
+            data_collator=collator_config_with_tokenizer,
             _convert_="object",
         )
 

--- a/src/train_lm.py
+++ b/src/train_lm.py
@@ -143,8 +143,7 @@ def train_lm(cfg: DictConfig) -> None:
     # data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
     collator_config = cfg.collator
     collator_config_with_tokenizer = {**collator_config, 'tokenizer': tokenizer}
-    data_collator = hydra.utils.instantiate(collator_config_with_tokenizer)
-    print(f"Data Collator settings: {data_collator}")
+    print(f"Data Collator settings: {collator_config_with_tokenizer}")
     
     with ExitStack() as stack:
         if "dynamic_resume" in cfg and cfg.dynamic_resume:


### PR DESCRIPTION
Added hydra config yml files to allow for training prefix LM. Configs for:

- collator / prefix modeling
- tokenizer / word level prefix
- train from prefix 
- train prefix transformer

Change in `train_lm.py`: when instantiating the trainer, pass in the data collator config dict rather than the instantiated object.
Made this change since I was running into a "missing 1 required positional argument" error when instantiating the trainer with hydra. Referred to [this issue](https://github.com/facebookresearch/hydra/issues/2591) for the fix!